### PR TITLE
fix: remove incorrect "type": "module" from core packages

### DIFF
--- a/libs/player-progress/package.json
+++ b/libs/player-progress/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@mintplayer/player-progress",
   "private": false,
-  "type": "module",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-video-player",

--- a/libs/player-provider/package.json
+++ b/libs/player-provider/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@mintplayer/player-provider",
   "private": false,
-  "type": "module",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-video-player",

--- a/libs/video-player/package.json
+++ b/libs/video-player/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@mintplayer/video-player",
   "private": false,
-  "type": "module",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "description": "Typescript video player supporting multiple platforms",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Removed `"type": "module"` from `video-player`, `player-provider`, and `player-progress` package.json files
- Same CJS/ESM mismatch as fixed in #96 for platform packages — these were missed
- Bumps to `19.1.1`

## Problem
`@mintplayer/ng-video-player` imports from `@mintplayer/video-player`, which still had `"type": "module"` with CommonJS code, causing:
```
Uncaught ReferenceError: exports is not defined
    at mintplayer-ng-video-player.mjs:4
```

## Test plan
- [x] `nx run-many --target=test --projects=video-player,player-provider,player-progress` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)